### PR TITLE
Enhance TimeseriesRepository to use ExpressionAttributeNames for addi…

### DIFF
--- a/src/market/db/__tests__/timeseries_repository.test.ts
+++ b/src/market/db/__tests__/timeseries_repository.test.ts
@@ -1,0 +1,67 @@
+import { TimeseriesRepository } from "@src/market/db/timeseries_repository";
+
+describe("TimeseriesRepository ProjectionExpression uses aliases for reserved attributes", () => {
+  function createMockDocClient(captured: any[]) {
+    return {
+      send: async (cmd: any) => {
+        captured.push(cmd.input ?? cmd);
+        return { Items: [] };
+      },
+    } as unknown as import("@aws-sdk/lib-dynamodb").DynamoDBDocumentClient;
+  }
+
+  it("queryBySymbolDateRange maps open/close/etc via ExpressionAttributeNames", async () => {
+    const captured: any[] = [];
+    const doc = createMockDocClient(captured);
+    const repo = new TimeseriesRepository({ tableName: "T", client: doc });
+    await repo.queryBySymbolDateRange({
+      code: "AAA",
+      fromDate: "2024-01-01",
+      toDate: "2024-01-10",
+    });
+
+    expect(captured).toHaveLength(1);
+    const input = captured[0];
+    expect(input.ExpressionAttributeNames).toMatchObject({
+      "#open": "open",
+      "#close": "close",
+      "#high": "high",
+      "#low": "low",
+      "#adj_close": "adj_close",
+      "#volume": "volume",
+      "#as_of_date": "as_of_date",
+      "#date": "date",
+    });
+    const proj: string = input.ProjectionExpression;
+    expect(proj).toContain("#open");
+    expect(proj).toContain("#close");
+    // Ensure raw names are not used directly to avoid reserved word conflicts
+    expect(proj.includes(" open,")).toBe(false);
+    expect(proj.includes(" close,")).toBe(false);
+  });
+
+  it("queryLatestBySymbol maps open/close/etc via ExpressionAttributeNames", async () => {
+    const captured: any[] = [];
+    const doc = createMockDocClient(captured);
+    const repo = new TimeseriesRepository({ tableName: "T", client: doc });
+    await repo.queryLatestBySymbol({ code: "AAA", limit: 5 });
+
+    expect(captured).toHaveLength(1);
+    const input = captured[0];
+    expect(input.ExpressionAttributeNames).toMatchObject({
+      "#open": "open",
+      "#close": "close",
+      "#high": "high",
+      "#low": "low",
+      "#adj_close": "adj_close",
+      "#volume": "volume",
+      "#as_of_date": "as_of_date",
+      "#date": "date",
+    });
+    const proj: string = input.ProjectionExpression;
+    expect(proj).toContain("#open");
+    expect(proj).toContain("#close");
+    expect(proj.includes(" open,")).toBe(false);
+    expect(proj.includes(" close,")).toBe(false);
+  });
+});

--- a/src/market/db/timeseries_repository.ts
+++ b/src/market/db/timeseries_repository.ts
@@ -62,12 +62,19 @@ export class TimeseriesRepository {
         ":from": fromSk,
         ":to": toSk,
       },
-      // Use ExpressionAttributeNames to avoid reserved keyword conflicts (e.g., "date")
+      // Use ExpressionAttributeNames to avoid reserved keyword conflicts (e.g., "date", "open", "close")
       ExpressionAttributeNames: {
         "#date": "date",
+        "#as_of_date": "as_of_date",
+        "#open": "open",
+        "#high": "high",
+        "#low": "low",
+        "#close": "close",
+        "#adj_close": "adj_close",
+        "#volume": "volume",
       },
       ProjectionExpression:
-        "gsi1sk, #date, as_of_date, open, high, low, close, adj_close, volume",
+        "gsi1sk, #date, #as_of_date, #open, #high, #low, #close, #adj_close, #volume",
       Limit: limit ?? inferredLimit,
       ScanIndexForward: true,
     });
@@ -106,9 +113,16 @@ export class TimeseriesRepository {
       // Avoid reserved attribute name conflicts
       ExpressionAttributeNames: {
         "#date": "date",
+        "#as_of_date": "as_of_date",
+        "#open": "open",
+        "#high": "high",
+        "#low": "low",
+        "#close": "close",
+        "#adj_close": "adj_close",
+        "#volume": "volume",
       },
       ProjectionExpression:
-        "gsi1sk, #date, as_of_date, open, high, low, close, adj_close, volume",
+        "gsi1sk, #date, #as_of_date, #open, #high, #low, #close, #adj_close, #volume",
       Limit: limit ?? 1,
       ScanIndexForward: false,
     });


### PR DESCRIPTION
…tional reserved attributes

- Updated ProjectionExpression in TimeseriesRepository to include aliases for reserved keywords such as "open", "close", "high", "low", "adj_close", and "volume" to prevent conflicts.
- Added unit tests to verify that the new aliases are correctly mapped and used in queries, ensuring robust handling of reserved attribute names.