### PR TITLE
Add TypeScript reference paths and clean up searchCatalog logic

### DIFF
--- a/deploy/api/graphql.ts
+++ b/deploy/api/graphql.ts
@@ -1,3 +1,4 @@
+/// <reference path="../../.sst/platform/config.d.ts" />
 import { GraphQLApiResources, LinkableResources } from "../types";
 
 /**

--- a/deploy/api/rest.ts
+++ b/deploy/api/rest.ts
@@ -2,7 +2,7 @@
  * REST API configurations
  * Manages all REST API endpoints and related resources
  */
-
+/// <reference path="../../.sst/platform/config.d.ts" />
 // Global sst declaration
 declare const sst: any;
 export function createRestApi(


### PR DESCRIPTION
- Added TypeScript reference paths to graphql.ts and rest.ts for improved type checking.
- Removed unused mockScan in market_search.test.ts and updated related tests for clarity.
- Refactored error handling in searchCatalog to improve logging and maintain best-effort results without fallback scans.
- Removed the scanCatalogFuzzy method from MarketDataRepository to streamline the codebase.