### PR TITLE
Enhance searchCatalog and MarketDataRepository pagination

### DIFF
--- a/src/__tests__/market_search.test.ts
+++ b/src/__tests__/market_search.test.ts
@@ -46,12 +46,16 @@ describe("searchCatalog business logic", () => {
       tableName,
     });
 
-    expect(mockQueryByMarket).toHaveBeenNthCalledWith(1, {
-      market: "CN_A",
-      q: "dev",
-      limit: 5,
-      maxPages: 10,
-    });
+    expect(mockQueryByMarket).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        market: "CN_A",
+        q: "dev",
+        limit: 5,
+        maxPages: 50,
+        pageSize: 80,
+      })
+    );
   });
 
   test("passes remaining limit to subsequent partitions", async () => {
@@ -70,18 +74,26 @@ describe("searchCatalog business logic", () => {
     });
 
     expect(out.count).toBe(3);
-    expect(mockQueryByMarket).toHaveBeenNthCalledWith(1, {
-      market: "CN_A",
-      q: "dev",
-      limit: 3,
-      maxPages: 10,
-    });
-    expect(mockQueryByMarket).toHaveBeenNthCalledWith(2, {
-      market: "US",
-      q: "dev",
-      limit: 1,
-      maxPages: 10,
-    });
+    expect(mockQueryByMarket).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        market: "CN_A",
+        q: "dev",
+        limit: 3,
+        maxPages: 50,
+        pageSize: 80,
+      })
+    );
+    expect(mockQueryByMarket).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        market: "US",
+        q: "dev",
+        limit: 1,
+        maxPages: 50,
+        pageSize: 80,
+      })
+    );
     expect(mockQueryByMarket).toHaveBeenCalledTimes(2);
   });
 

--- a/src/market/db/marketdata_repository.test.ts
+++ b/src/market/db/marketdata_repository.test.ts
@@ -70,6 +70,39 @@ describe("MarketDataRepository", () => {
     expect(mockSend).toHaveBeenCalledTimes(20);
   });
 
+  test("queryCatalogByMarketFuzzy uses wider page size than requested limit", async () => {
+    mockSend.mockResolvedValueOnce({
+      Items: [{ symbol: "CN1", name: "China One" }],
+    });
+
+    const repo = createRepo();
+    await repo.queryCatalogByMarketFuzzy({
+      market: "CN_A",
+      q: "c",
+      limit: 2,
+    });
+
+    const sent = mockSend.mock.calls[0]?.[0] as { input: Record<string, any> };
+    expect(sent.input.Limit).toBeGreaterThan(2);
+  });
+
+  test("queryCatalogByMarketFuzzy respects explicit pageSize", async () => {
+    mockSend.mockResolvedValueOnce({
+      Items: [{ symbol: "US1", name: "US Stock" }],
+    });
+
+    const repo = createRepo();
+    await repo.queryCatalogByMarketFuzzy({
+      market: "US",
+      q: "us",
+      limit: 5,
+      pageSize: 150,
+    });
+
+    const sent = mockSend.mock.calls[0]?.[0] as { input: Record<string, any> };
+    expect(sent.input.Limit).toBe(150);
+  });
+
   test("queryCatalogPage returns cursor and respects optional filters", async () => {
     mockSend.mockResolvedValueOnce({
       Items: [{ symbol: "US1", name: "US Stock" }],

--- a/src/market/search_catalog.ts
+++ b/src/market/search_catalog.ts
@@ -19,7 +19,8 @@ export interface SearchCatalogOutput {
 
 const DEFAULT_LIMIT = 5;
 const DEFAULT_MARKET_PARTITIONS = ["CN_A", "US", "INDEX", "ETF"];
-const MARKET_QUERY_MAX_PAGES = 10;
+const MARKET_QUERY_MAX_PAGES = 50;
+const MARKET_QUERY_PAGE_SIZE = 80;
 
 export async function searchCatalog(
   input: SearchCatalogInput
@@ -63,6 +64,7 @@ export async function searchCatalog(
       q,
       limit: remaining,
       maxPages: MARKET_QUERY_MAX_PAGES,
+      pageSize: Math.max(MARKET_QUERY_PAGE_SIZE, remaining * 5),
     });
     await add(part);
   }


### PR DESCRIPTION
- Updated the maximum query pages in MarketDataRepository from 10 to 50 and introduced a new page size of 80.
- Modified searchCatalog to utilize the new pagination settings, ensuring that the page size is calculated based on the remaining limit.
- Enhanced unit tests in market_search.test.ts to verify the updated pagination behavior and limits for market queries.
- Added new tests in marketdata_repository.test.ts to validate that the queryCatalogByMarketFuzzy method respects the new page size and limit configurations.